### PR TITLE
feat: Add GitHub Action for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,52 @@
+# .goreleaser.yml
+version: 2
+project_name: terraform-graphx
+
+builds:
+  - id: terraform-graphx
+    main: ./main.go
+    binary: terraform-graphx
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: terraform-graphx
+    builds:
+      - terraform-graphx
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+release:
+  draft: false
+  prerelease: auto
+  name_template: "{{.Tag}}"
+  body: |
+    {{ .Title }}
+
+    {{ .Changelog }}

--- a/README.md
+++ b/README.md
@@ -11,19 +11,45 @@
 
 ## Installation
 
-1.  **Build from source:**
+You can install `terraform-graphx` by downloading a pre-compiled binary or by building it from source.
+
+### Pre-compiled Binaries (Recommended)
+
+The easiest way to install `terraform-graphx` is to download the latest release from the **GitHub Releases** page for this repository.
+
+1.  Download the archive for your operating system and architecture.
+2.  Extract the `terraform-graphx` binary.
+3.  Move the binary to a directory in your system's `PATH`. The binary must be named `terraform-graphx` for Terraform to detect it as a subcommand.
+
+**Example for Linux/macOS:**
+```bash
+# Replace with the correct URL from the releases page
+wget <URL_TO_TAR.GZ>
+tar -xzf terraform-graphx_*.tar.gz
+sudo mv terraform-graphx /usr/local/bin/
+```
+
+### Build from Source
+
+If you have Go (version 1.22+) installed, you can build `terraform-graphx` from source.
+
+1.  Clone the repository:
+    ```bash
+    git clone https://github.com/daniellvog/terraform-graphx.git
+    cd terraform-graphx
+    ```
+
+2.  Build the binary:
     ```bash
     go build -o terraform-graphx .
     ```
 
-2.  **Place the binary in your `PATH`:**
-    To use `terraform-graphx` as a Terraform subcommand, the binary must be named `terraform-graphx` and be available in your system's `PATH`.
+3.  Place the binary in your `PATH`:
     ```bash
-    mv terraform-graphx /usr/local/bin/
+    sudo mv terraform-graphx /usr/local/bin/
     ```
 
-3.  **Verify installation:**
-    The `graphx` command should now appear in the Terraform help output.
+4.  Verify the installation:
     ```bash
     terraform -help
     ```


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the release process for the `terraform-graphx` tool. It also adds a `.goreleaser.yml` configuration to build the application for multiple platforms and updates the README with installation instructions for the pre-compiled binaries.

The new workflow will trigger on new version tags (e.g., `v1.0.0`) and will:
- Build the Go application for Linux, macOS, and Windows on amd64 and arm64 architectures.
- Create a GitHub release with the compiled binaries and checksums as downloadable artifacts.

The `README.md` has been updated to prioritize installation via these pre-compiled binaries, making it easier for users to get started.