### PR TITLE
fix(ci): pin GoReleaser version to v2.12.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.12.5
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GitHub Actions release workflow was failing due to a version mismatch between the GoReleaser configuration file (`.goreleaser.yml`) and the GoReleaser binary used by the `goreleaser/goreleaser-action`.

The configuration file uses `version: 2` syntax, but the workflow was using the `version: latest` input, which was resolving to an older GoReleaser binary that only supports the v1 configuration format.

This change pins the GoReleaser binary to a specific, recent, and stable version (`v2.12.5`) that is compatible with the v2 configuration, resolving the build failure.