### PR TITLE
Fix: Correct GoReleaser configuration to use release_notes

### DIFF
--- a/.github/release-notes.md.tpl
+++ b/.github/release-notes.md.tpl
@@ -1,0 +1,1 @@
+{{ .Changelog }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,5 @@ release:
   draft: false
   prerelease: auto
   name_template: "{{.Tag}}"
-  body: |
-    {{ .Title }}
-
-    {{ .Changelog }}
+  release_notes:
+    template: ".github/release-notes.md.tpl"


### PR DESCRIPTION
The GitHub Actions workflow was failing due to a misconfiguration in the `.goreleaser.yml` file. The `body` field in the `release` section is not supported in the GoReleaser version being used (v2.12.5).

This commit replaces the deprecated `body` field with the `release_notes` field and points it to a new template file, `.github/release-notes.md.tpl`. This resolves the `yaml: unmarshal errors` and allows the release workflow to proceed.