### PR TITLE
fix: Correct .goreleaser.yml structure

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,5 +46,6 @@ release:
   draft: false
   prerelease: auto
   name_template: "{{.Tag}}"
-  release_notes:
-    template: ".github/release-notes.md.tpl"
+
+release_notes:
+  template: ".github/release-notes.md.tpl"


### PR DESCRIPTION
The `release_notes` section was incorrectly nested inside the `release` section, which is invalid syntax for GoReleaser v2. This caused the release GitHub Action to fail with a YAML unmarshalling error.

This commit moves the `release_notes` section to be a top-level key in the `.goreleaser.yml` file, aligning it with the correct configuration structure.